### PR TITLE
Accept exp and nbf in ms

### DIFF
--- a/examples/basic_usage.cr
+++ b/examples/basic_usage.cr
@@ -9,3 +9,9 @@ pp token
 payload, header = JWT.decode(token, "SecretKey", "HS256")
 pp payload
 pp header
+
+# ArangoDB 3.1.23 JWT token
+p "ArangoDB debug"
+payload, header = JWT.decode("eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJ1aWQiOiI4MjY4OTEwOSIsImlhdCI6MTUwMzM5NDAwNjI1NSwicGF5bG9hZCI6eyJyb2xlIjoiRWxldmUiLCJlbWFpbCI6ImVsZXZlMUBlc3NhaS5jb20iLCJ1c2VybmFtZSI6IlAuQkFSUkVTIn0sImV4cCI6MTUwMzM5NzYwNjI1OH0.FcfRg1JYqIT9ZQQneEDRbt16_ltN6dyAfuFezsN0uBJ8jO-jAPzUYqlRJ77hKvjF2h51jvdtII5GVoEw72TIyw", "fJShJ9ZH0c05eXZNzi0qcBV3WeLar2Vi9zIdo8Ggbk3LoLTpkzTef8L0AYlwzcO1YotNsaBydIYk50F2", "HS512")
+pp payload
+pp header

--- a/examples/basic_usage.cr
+++ b/examples/basic_usage.cr
@@ -10,8 +10,7 @@ payload, header = JWT.decode(token, "SecretKey", "HS256")
 pp payload
 pp header
 
-# ArangoDB 3.1.23 JWT token
-p "ArangoDB debug"
+# exp field in ms
 payload, header = JWT.decode("eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJ1aWQiOiI4MjY4OTEwOSIsImlhdCI6MTUwMzM5NDAwNjI1NSwicGF5bG9hZCI6eyJyb2xlIjoiRWxldmUiLCJlbWFpbCI6ImVsZXZlMUBlc3NhaS5jb20iLCJ1c2VybmFtZSI6IlAuQkFSUkVTIn0sImV4cCI6MTUwMzM5NzYwNjI1OH0.FcfRg1JYqIT9ZQQneEDRbt16_ltN6dyAfuFezsN0uBJ8jO-jAPzUYqlRJ77hKvjF2h51jvdtII5GVoEw72TIyw", "fJShJ9ZH0c05eXZNzi0qcBV3WeLar2Vi9zIdo8Ggbk3LoLTpkzTef8L0AYlwzcO1YotNsaBydIYk50F2", "HS512")
 pp payload
 pp header

--- a/src/jwt.cr
+++ b/src/jwt.cr
@@ -21,8 +21,10 @@ module JWT
     unless segments.size == 3
       raise DecodeError.new("Not enough or too many segments in the token")
     end
+
     encoded_header, encoded_payload, encoded_signature = segments
     expected_encoded_signature = encoded_signature(algorithm, key, "#{encoded_header}.#{encoded_payload}")
+
     if encoded_signature != expected_encoded_signature
       raise VerificationError.new("Signature verification failed")
     end

--- a/src/jwt.cr
+++ b/src/jwt.cr
@@ -21,10 +21,8 @@ module JWT
     unless segments.size == 3
       raise DecodeError.new("Not enough or too many segments in the token")
     end
-
     encoded_header, encoded_payload, encoded_signature = segments
     expected_encoded_signature = encoded_signature(algorithm, key, "#{encoded_header}.#{encoded_payload}")
-
     if encoded_signature != expected_encoded_signature
       raise VerificationError.new("Signature verification failed")
     end
@@ -82,12 +80,16 @@ module JWT
   end
 
   private def validate_exp!(exp)
+    # Check if we receive exp as ms instead of s
+    exp = exp.to_s.to_i64 / 1000 if exp.to_s.size == 13
     if exp.to_s.to_i < Time.now.epoch
       raise ExpiredSignatureError.new("Signature is expired")
     end
   end
 
   private def validate_nbf!(nbf)
+    # Check if we receive nbf as ms instead of s
+    nbf = nbf.to_s.to_i64 / 1000 if nbf.to_s.size == 13
     if nbf.to_s.to_i > Time.now.epoch
       raise ImmatureSignatureError.new("Signature nbf has not been reached")
     end


### PR DESCRIPTION
Some JWT tokens contains time fields in ms instead of seconds and it raise an error.

This PR just convert time in seconds if needed and validate then the token