### PR TITLE
Fix for crystal 0.25

### DIFF
--- a/src/jwt.cr
+++ b/src/jwt.cr
@@ -96,13 +96,13 @@ module JWT
   private def validate_aud!(payload, aud)
     if !payload["aud"]?
       raise InvalidAudienceError.new("Invalid audience (aud). Expected #{aud.inspect}, received nothing")
-    elsif payload["aud"].is_a?(String)
+    elsif payload["aud"].as_s?
       if aud != payload["aud"]
         raise InvalidAudienceError.new("Invalid audience (aud). Expected #{aud.inspect}, received #{payload["aud"].inspect}")
       end
-    elsif payload["aud"].is_a?(Array)
+    elsif payload["aud"].as_a?
       # to prevent compile-time error
-      auds = payload["aud"].as(Array)
+      auds = payload["aud"].as_a
       if !auds.includes?(aud)
         msg = "Invalid audience (aud). Expected #{aud.inspect}, received #{payload["aud"].inspect}"
         raise InvalidAudienceError.new(msg)


### PR DESCRIPTION
Hi! Build was failing for new crystal version because of changes done on https://github.com/crystal-lang/crystal/pull/5183

I have updated `validated_aud!` method to use new `as_a?` and `as_s`.