### PR TITLE
Crystal 0.27 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Example:
 
 ```crystal
 # Create token that expires in 1 minute
-exp = Time.now.epoch + 60
+exp = Time.now.to_unix + 60
 payload = { "foo" => "bar", "exp" => exp }
 token = JWT.encode(payload, "SecretKey", "HS256")
 
@@ -87,7 +87,7 @@ Example:
 
 ```crystal
 # Create token that will become acceptable in 1 minute
-nbf = Time.now.epoch + 60
+nbf = Time.now.to_unix + 60
 payload = { "foo" => "bar", "nbf" => nbf }
 token = JWT.encode(payload, "SecretKey", "HS256")
 
@@ -101,7 +101,7 @@ From [RFC 7519](https://tools.ietf.org/html/rfc7519#section-4.1.6):
 
 Example:
 ```crystal
-payload = { "foo" => "bar", "iat" => Time.now.epoch }
+payload = { "foo" => "bar", "iat" => Time.now.to_unix }
 token = JWT.encode(payload, "SecretKey", "HS256")
 ```
 

--- a/examples/exp_claim.cr
+++ b/examples/exp_claim.cr
@@ -1,7 +1,7 @@
 require "../src/jwt"
 
 # Create token that expires in 1 minute
-exp = Time.now.epoch + 60
+exp = Time.now.to_unix + 60
 payload = {"foo" => "bar", "exp" => exp}
 token = JWT.encode(payload, "SecretKey", "HS256")
 

--- a/examples/iat_claim.cr
+++ b/examples/iat_claim.cr
@@ -1,5 +1,5 @@
 require "../src/jwt"
 
 # Create token with iat claim:
-payload = {"foo" => "bar", "iat" => Time.now.epoch}
+payload = {"foo" => "bar", "iat" => Time.now.to_unix}
 token = JWT.encode(payload, "SecretKey", "HS256")

--- a/examples/nbf_claim.cr
+++ b/examples/nbf_claim.cr
@@ -1,7 +1,7 @@
 require "../src/jwt"
 
 # Create token that will become acceptable in 1 minute
-nbf = Time.now.epoch + 60
+nbf = Time.now.to_unix + 60
 payload = {"foo" => "bar", "nbf" => nbf}
 token = JWT.encode(payload, "SecretKey", "HS256")
 

--- a/spec/integration/claims/exp_spec.cr
+++ b/spec/integration/claims/exp_spec.cr
@@ -3,7 +3,7 @@ require "../../spec_helper"
 describe "exp claim" do
   context "exp is in the future" do
     it "token is accepted" do
-      exp = Time.now.epoch + 10
+      exp = Time.now.to_unix + 10
       payload = {"exp" => exp}
       token = JWT.encode(payload, "key", "HS256")
       payload, header = JWT.decode(token, "key", "HS256")
@@ -13,7 +13,7 @@ describe "exp claim" do
 
   context "exp is in the past" do
     it "raises VerificationError" do
-      exp = Time.now.epoch - 1
+      exp = Time.now.to_unix - 1
       payload = {"exp" => exp}
       token = JWT.encode(payload, "key", "HS256")
       expect_raises(JWT::ExpiredSignatureError, "Signature is expired") do

--- a/spec/integration/claims/nbf_spec.cr
+++ b/spec/integration/claims/nbf_spec.cr
@@ -3,7 +3,7 @@ require "../../spec_helper"
 describe "nbf claim" do
   context "nbf is in the future" do
     it "raises ImmatureSignatureError" do
-      nbf = Time.now.epoch + 2
+      nbf = Time.now.to_unix + 2
       payload = {"nbf" => nbf}
       token = JWT.encode(payload, "key", "HS256")
       expect_raises(JWT::ImmatureSignatureError, "Signature nbf has not been reached") do
@@ -14,7 +14,7 @@ describe "nbf claim" do
 
   context "nbf is now" do
     it "accepts token" do
-      nbf = Time.now.epoch
+      nbf = Time.now.to_unix
       payload = {"nbf" => nbf}
       token = JWT.encode(payload, "key", "HS256")
       payload, header = JWT.decode(token, "key", "HS256")
@@ -24,7 +24,7 @@ describe "nbf claim" do
 
   context "nbf is in the past" do
     it "accepts token" do
-      nbf = Time.now.epoch - 1
+      nbf = Time.now.to_unix - 1
       payload = {"nbf" => nbf}
       token = JWT.encode(payload, "key", "HS256")
       payload, header = JWT.decode(token, "key", "HS256")

--- a/src/jwt.cr
+++ b/src/jwt.cr
@@ -82,13 +82,13 @@ module JWT
   end
 
   private def validate_exp!(exp)
-    if exp.to_s.to_i < Time.now.epoch
+    if exp.to_s.to_i < Time.now.to_unix
       raise ExpiredSignatureError.new("Signature is expired")
     end
   end
 
   private def validate_nbf!(nbf)
-    if nbf.to_s.to_i > Time.now.epoch
+    if nbf.to_s.to_i > Time.now.to_unix
       raise ImmatureSignatureError.new("Signature nbf has not been reached")
     end
   end


### PR DESCRIPTION
Only one breaking change affects this library:

```
Rename Time#epoch to Time#to_unix. Also #epoch_ms to #unix_ms, and #epoch_f to #to_unix_f.
```