### PR TITLE
Add an argument for skipping secret verification

### DIFF
--- a/spec/integration/algorithms/hmac_spec.cr
+++ b/spec/integration/algorithms/hmac_spec.cr
@@ -26,10 +26,23 @@ describe JWT do
 
       describe "#decode" do
         context "when token was signed with another key" do
-          it "raises JWT::VerificationError" do
-            token = JWT.encode(payload, wrong_key, alg)
-            expect_raises(JWT::VerificationError, "Signature verification failed") do
-              JWT.decode(token, secret_key, alg)
+          context "when verify argument is true" do
+            it "raises JWT::VerificationError" do
+              token = JWT.encode(payload, wrong_key, alg)
+              expect_raises(JWT::VerificationError, "Signature verification failed") do
+                JWT.decode(token, secret_key, alg)
+              end
+            end
+          end
+
+          context "when verify argument is false" do
+            it "decodes the token" do
+              token = JWT.encode(payload, wrong_key, alg)
+
+              decoded_token = JWT.decode(token, "", alg, verify: false)
+
+              decoded_token[0].should eq(payload)
+              decoded_token[1].should eq({"typ" => "JWT", "alg" => alg})
             end
           end
         end

--- a/src/jwt.cr
+++ b/src/jwt.cr
@@ -15,7 +15,7 @@ module JWT
     segments.join(".")
   end
 
-  def decode(token : String, key : String, algorithm : String, **opts) : Tuple
+  def decode(token : String, key : String, algorithm : String, verify : Bool = true, **opts) : Tuple
     segments = token.split(".")
 
     unless segments.size == 3
@@ -23,10 +23,13 @@ module JWT
     end
 
     encoded_header, encoded_payload, encoded_signature = segments
-    expected_encoded_signature = encoded_signature(algorithm, key, "#{encoded_header}.#{encoded_payload}")
 
-    if encoded_signature != expected_encoded_signature
-      raise VerificationError.new("Signature verification failed")
+    if verify
+      expected_encoded_signature = encoded_signature(algorithm, key, "#{encoded_header}.#{encoded_payload}")
+
+      if encoded_signature != expected_encoded_signature
+        raise VerificationError.new("Signature verification failed")
+      end
     end
 
     header_json = Base64.decode_string(encoded_header)


### PR DESCRIPTION
In some environments, e.g. behind a Kong gateway, you may be doing secret verification in a different place and want to skip it in your app.