### PR TITLE
fix JWT::UnsupportedAlgorithmError typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ token = JWT.encode(payload, "SecretKey", JWT::Algorithm::HS256)
     * JWT::InvalidAudienceError
     * JWT::InvalidIssuerError
     * JWT::InvalidSubjectError
-  * UnsupportedAlogrithmError
+  * UnsupportedAlgorithmError
 
 ## Test
 

--- a/src/jwt.cr
+++ b/src/jwt.cr
@@ -104,7 +104,7 @@ module JWT
       OpenSSL::RSA.new(key).sign(OpenSSL::Digest.new("sha384"), data)
     when Algorithm::RS512
       OpenSSL::RSA.new(key).sign(OpenSSL::Digest.new("sha512"), data)
-    else raise(UnsupportedAlogrithmError.new("Unsupported algorithm: #{algorithm}"))
+    else raise(UnsupportedAlgorithmError.new("Unsupported algorithm: #{algorithm}"))
     end
   end
 

--- a/src/jwt/errors.cr
+++ b/src/jwt/errors.cr
@@ -3,7 +3,7 @@ module JWT
   class Error < ::Exception; end
 
   # Is raised on attempt to use unsupported algorithm.
-  class UnsupportedAlogrithmError < Error; end
+  class UnsupportedAlgorithmError < Error; end
 
   # raised when failed to decode token
   class DecodeError < Error; end


### PR DESCRIPTION
Rename `JWT::UnsupportedAlogrithmError` to `JWT::UnsupportedAlgorithmError`