### PR TITLE
Use Time.utc instead of deprecated Time.now

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Example:
 
 ```crystal
 # Create token that expires in 1 minute
-exp = Time.now.to_unix + 60
+exp = Time.utc.to_unix + 60
 payload = { "foo" => "bar", "exp" => exp }
 token = JWT.encode(payload, "SecretKey", JWT::Algorithm::HS256)
 
@@ -96,7 +96,7 @@ Example:
 
 ```crystal
 # Create token that will become acceptable in 1 minute
-nbf = Time.now.to_unix + 60
+nbf = Time.utc.to_unix + 60
 payload = { "foo" => "bar", "nbf" => nbf }
 token = JWT.encode(payload, "SecretKey", JWT::Algorithm::HS256)
 
@@ -110,7 +110,7 @@ From [RFC 7519](https://tools.ietf.org/html/rfc7519#section-4.1.6):
 
 Example:
 ```crystal
-payload = { "foo" => "bar", "iat" => Time.now.to_unix }
+payload = { "foo" => "bar", "iat" => Time.utc.to_unix }
 token = JWT.encode(payload, "SecretKey", JWT::Algorithm::HS256)
 ```
 

--- a/examples/exp_claim.cr
+++ b/examples/exp_claim.cr
@@ -1,7 +1,7 @@
 require "../src/jwt"
 
 # Create token that expires in 1 minute
-exp = Time.now.to_unix + 60
+exp = Time.utc.to_unix + 60
 payload = {"foo" => "bar", "exp" => exp}
 token = JWT.encode(payload, "SecretKey", JWT::Algorithm::HS256)
 

--- a/examples/iat_claim.cr
+++ b/examples/iat_claim.cr
@@ -1,5 +1,5 @@
 require "../src/jwt"
 
 # Create token with iat claim:
-payload = {"foo" => "bar", "iat" => Time.now.to_unix}
+payload = {"foo" => "bar", "iat" => Time.utc.to_unix}
 token = JWT.encode(payload, "SecretKey", JWT::Algorithm::HS256)

--- a/examples/nbf_claim.cr
+++ b/examples/nbf_claim.cr
@@ -1,7 +1,7 @@
 require "../src/jwt"
 
 # Create token that will become acceptable in 1 minute
-nbf = Time.now.to_unix + 60
+nbf = Time.utc.to_unix + 60
 payload = {"foo" => "bar", "nbf" => nbf}
 token = JWT.encode(payload, "SecretKey", JWT::Algorithm::HS256)
 


### PR DESCRIPTION
The code in README.md contains the deprecated Time.now method, which causes compiler warnings.