### PR TITLE
Avoid unnecessary work in the encode step to remove padding ('=' chars)

### DIFF
--- a/src/jwt.cr
+++ b/src/jwt.cr
@@ -137,7 +137,7 @@ module JWT
   end
 
   private def base64_encode(data)
-    Base64.urlsafe_encode(data).gsub /\=+/, ""
+    Base64.urlsafe_encode(data, false)
   end
 
   private def validate_exp!(exp)


### PR DESCRIPTION
Crystal's Base64 implementation already supports optional padding. The
JWT library is essentially doing additional work to pad and then 'unpad'
the encoded string.

https://github.com/crystal-lang/crystal/blob/64d0a1dfe5eb8bff5d41c6a162bb78012c5f9ea2/src/base64.cr#L140

Benchmark of the diff:
```
         base64 w/ gsub and None alg 502.42k (  1.99µs) (± 0.47%)  1.54kB/op   1.56× slower
base64 w/ padding=false and None alg 785.06k (  1.27µs) (± 0.87%)  1.14kB/op        fastest

         base64 w/ gsub and HS256 alg 220.93k (  4.53µs) (± 0.82%)  1.7kB/op   1.21× slower
base64 w/ padding=false and HS256 alg 266.85k (  3.75µs) (± 0.42%)  1.3kB/op        fastest
````