### PR TITLE
Use OpenSSL::Digest#final

### DIFF
--- a/src/jwt.cr
+++ b/src/jwt.cr
@@ -49,7 +49,7 @@ module JWT
         end
       when Algorithm::ES256, Algorithm::ES384, Algorithm::ES512
         dsa = OpenSSL::PKey::EC.new(key)
-        digest = OpenSSL::Digest.new("sha#{algorithm.to_s[2..-1]}").update(verify_data).digest
+        digest = OpenSSL::Digest.new("sha#{algorithm.to_s[2..-1]}").update(verify_data).final
         result = begin
           dsa.ec_verify(digest, raw_to_asn1(Base64.decode(encoded_signature), dsa))
         rescue e
@@ -122,15 +122,15 @@ module JWT
       OpenSSL::PKey::RSA.new(key).sign(OpenSSL::Digest.new("sha512"), data)
     when Algorithm::ES256
       pkey = OpenSSL::PKey::EC.new(key)
-      asn1_to_raw(pkey.ec_sign(OpenSSL::Digest.new("sha256").update(data).digest), pkey)
+      asn1_to_raw(pkey.ec_sign(OpenSSL::Digest.new("sha256").update(data).final), pkey)
     when Algorithm::ES384
       pkey = OpenSSL::PKey::EC.new(key)
-      asn1_to_raw(pkey.ec_sign(OpenSSL::Digest.new("sha384").update(data).digest), pkey)
+      asn1_to_raw(pkey.ec_sign(OpenSSL::Digest.new("sha384").update(data).final), pkey)
     when Algorithm::ES512
       # https://tools.ietf.org/html/rfc7518#section-3.4
       # NOTE:: key size 521 for ES512
       pkey = OpenSSL::PKey::EC.new(key)
-      asn1_to_raw(pkey.ec_sign(OpenSSL::Digest.new("sha512").update(data).digest), pkey)
+      asn1_to_raw(pkey.ec_sign(OpenSSL::Digest.new("sha512").update(data).final), pkey)
     else
       raise(UnsupportedAlgorithmError.new("Unsupported algorithm: #{algorithm}"))
     end


### PR DESCRIPTION
This are the changes need to upgrade to Crystal 0.35

Related to changes in shards 0.11 I recommend adding a crystal property in the shard.yml to state which crystal version are expected to be used with this shard.

If compatibility with older versions is wanted `{% if compare_versions(Crystal::VERSION, "0.35.0-0") >= 0 %}` can be used.

Both dependencies should be updated also
* https://github.com/stakach/openssl_ext/pull/1
* https://github.com/spider-gazelle/bindata/pull/5


