### PR TITLE
Fix for Crystal 0.35.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -8,10 +8,10 @@ authors:
 dependencies:
   openssl_ext:
     github: stakach/openssl_ext
-    version: ~> 1.2
+    version: ">= 1.2.1, < 1.3"
 
   bindata:
     github: spider-gazelle/bindata
-    version: ~> 1.5
+    version: ">= 1.5.4, < 1.6"
 
 license: MIT


### PR DESCRIPTION
I ran into the below error until I updated the dependencies.
```
06:31 $ crystal spec
Showing last frame. Use --error-trace for full trace.

In /usr/local/Cellar/crystal/0.35.0/src/io.cr:845:34

 845 | def write_byte(byte : UInt8) : Int64
                                      ^
Error: method must return Int64 but it is returning (Int64 | Nil)
```
https://github.com/stakach/openssl_ext/compare/v1.2.0...stakach:v1.2.1
https://github.com/spider-gazelle/bindata/compare/v1.5.3...v1.5.4

More background: https://github.com/crystal-lang/crystal/issues/9454