### PR TITLE
Support for dynamic key & auto selecting algorithm by JWT header

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ payload, header = JWT.decode(token, "$secretKey", JWT::Algorithm::HS256)
 payload, header = JWT.decode(token, verify: false, validate: false)
 # Verification checks the signature
 # Validation is checking if the token has expired etc
+
+# You may also dynamically decide the key by passing a block to the decode function
+# algorithm is optionally, you can omit it to use algorithm defined in the header
+payload, header = JWT.decode(token, JWT::Algorithm::HS256) do |header, payload|
+  "the key"
+end
 ```
 
 ## Supported algorithms

--- a/spec/jwt_spec.cr
+++ b/spec/jwt_spec.cr
@@ -17,6 +17,24 @@ describe JWT do
       header.should eq({"typ" => "JWT", "alg" => "HS256"})
       payload.should eq({"k1" => "v1", "k2" => "v2"})
     end
+
+    it "decodes and verifies JWT with dynamic key" do
+      token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJrMSI6InYxIiwiazIiOiJ2MiJ9.spzfy63YQSKdoM3av9HHvLtWzFjPd1hbch2g3T1-nu4"
+      payload, header = JWT.decode(token, algorithm: JWT::Algorithm::HS256) do |header, payload|
+        "SecretKey"
+      end
+      header.should eq({"typ" => "JWT", "alg" => "HS256"})
+      payload.should eq({"k1" => "v1", "k2" => "v2"})
+    end
+
+    it "decodes and verifies JWT with dynamic key and auto algorithm" do
+      token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJrMSI6InYxIiwiazIiOiJ2MiJ9.spzfy63YQSKdoM3av9HHvLtWzFjPd1hbch2g3T1-nu4"
+      payload, header = JWT.decode(token) do |header, payload|
+        "SecretKey"
+      end
+      header.should eq({"typ" => "JWT", "alg" => "HS256"})
+      payload.should eq({"k1" => "v1", "k2" => "v2"})
+    end
   end
 
   describe "#encode_header" do

--- a/src/jwt.cr
+++ b/src/jwt.cr
@@ -34,25 +34,14 @@ module JWT
   def decode(token : String, key : String = "", algorithm : Algorithm = Algorithm::None, verify = true, validate = true, **options) : Tuple
     verify_data, _, encoded_signature = token.rpartition('.')
 
-    count = verify_data.count('.')
-    if count != 1
-      raise DecodeError.new("Invalid number of segments in the token. Expected 3 got #{count + 2}")
-    end
+    check_verify_data(verify_data)
+
     verify(key, algorithm, verify_data, encoded_signature) if verify
 
-    encoded_header, encoded_payload = verify_data.split('.')
-    header_json = Base64.decode_string(encoded_header)
-    header = JSON.parse(header_json).as_h
-
-    payload_json = Base64.decode_string(encoded_payload)
-    payload = JSON.parse(payload_json)
+    header, payload = decode_verify_data(verify_data)
     validate(payload, options) if validate
 
     {payload, header}
-  rescue error : Base64::Error
-    raise DecodeError.new("Invalid Base64", error)
-  rescue error : JSON::ParseException
-    raise DecodeError.new("Invalid JSON", error)
   rescue error : TypeCastError
     raise DecodeError.new("Invalid JWT payload", error)
   end
@@ -60,10 +49,34 @@ module JWT
   def decode(token : String, algorithm : Algorithm? = nil, verify = true, validate = true, **options, &block) : Tuple
     verify_data, _, encoded_signature = token.rpartition('.')
 
+    check_verify_data(verify_data)
+    header, payload = decode_verify_data(verify_data)
+
+    if algorithm.nil?
+      begin
+        algorithm = Algorithm.parse header["alg"].as_s
+      rescue error : ArgumentError | KeyError
+        raise DecodeError.new("Invalid alg in JWT header", error)
+      end
+    end
+    key = yield header, payload
+
+    verify(key.not_nil!, algorithm.not_nil!, verify_data, encoded_signature) if verify
+    validate(payload, options) if validate
+
+    {payload, header}
+  rescue error : TypeCastError
+    raise DecodeError.new("Invalid JWT payload", error)
+  end
+
+  private def check_verify_data(verify_data)
     count = verify_data.count('.')
     if count != 1
       raise DecodeError.new("Invalid number of segments in the token. Expected 3 got #{count + 2}")
     end
+  end
+
+  private def decode_verify_data(verify_data)
     encoded_header, encoded_payload = verify_data.split('.')
     header_json = Base64.decode_string(encoded_header)
     header = JSON.parse(header_json).as_h
@@ -71,23 +84,13 @@ module JWT
     payload_json = Base64.decode_string(encoded_payload)
     payload = JSON.parse(payload_json)
 
-    algorithm = Algorithm.parse header["alg"].as_s if algorithm.nil?
-
-    key = yield header, payload
-
-    verify(key, algorithm.not_nil!, verify_data, encoded_signature) if verify
-
-    validate(payload, options) if validate
-
-    {payload, header}
+    { header, payload }
   rescue error : Base64::Error
     raise DecodeError.new("Invalid Base64", error)
   rescue error : JSON::ParseException
     raise DecodeError.new("Invalid JSON", error)
   rescue error : TypeCastError
-    raise DecodeError.new("Invalid JWT payload", error)
-  rescue error : ArgumentError | KeyError
-    raise DecodeError.new("Invalid alg in JWT header", error)
+    raise DecodeError.new("Invalid JWT header", error)
   end
 
   # public key verification for RSA and ECDSA algorithms

--- a/src/jwt.cr
+++ b/src/jwt.cr
@@ -57,7 +57,7 @@ module JWT
     raise DecodeError.new("Invalid JWT payload", error)
   end
 
-  def decode(token : String, key : String = "", algorithm : Algorithm? = nil, verify = true, validate = true, **options, &block) : Tuple
+  def decode(token : String, algorithm : Algorithm? = nil, verify = true, validate = true, **options, &block) : Tuple
     verify_data, _, encoded_signature = token.rpartition('.')
 
     count = verify_data.count('.')


### PR DESCRIPTION
Support dynamic key by passing a block, which makes selecting key by header/payload possible.
Also support auto selecting algorithm by the alg field of JWT header, which may be required as we may want support multiple algorithms and choose different type of key for each algorithm.